### PR TITLE
Added optional bitwarden_root_cert config to trust an additional root certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Configuration values are as follows:
 |----|----|--------|-----------|
 |`bitwarden_url`|String||The root URL for accessing `bitwarden_rs`. Eg: `https://bw.example.com`|
 |`bitwarden_admin_token`|String||The value passed as `ADMIN_TOKEN` to `bitwarden_rs`|
+|`bitwarden_root_cert`|String|Optional|Additional der-encoded root certificate to trust for accessing `bitwarden_rs`|
 |`ldap_host`|String||The hostname or IP address for your ldap server|
 |`ldap_scheme`|String|Optional|The that should be used to connect. `ldap` or `ldaps`. This is set by default based on SSL settings|
 |`ldap_ssl`|Boolean|Optional|Indicates if SSL should be used. Defaults to `false`|

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub struct Config {
     // Bitwarden connection config
     bitwarden_url: String,
     bitwarden_admin_token: String,
+    bitwarden_root_cert: Option<String>,
     // LDAP Connection config
     ldap_host: String,
     ldap_scheme: Option<String>,
@@ -69,6 +70,13 @@ impl Config {
 
     pub fn get_bitwarden_admin_token(&self) -> String {
         self.bitwarden_admin_token.clone()
+    }
+
+    pub fn get_bitwarden_root_cert(&self) -> String {
+		match &self.bitwarden_root_cert {
+            Some(bitwarden_root_cert) => bitwarden_root_cert.clone(),
+            None => String::new(),
+        }
     }
 
     pub fn get_ldap_url(&self) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
     let mut client = bw_admin::Client::new(
         config.get_bitwarden_url().clone(),
         config.get_bitwarden_admin_token().clone(),
+        config.get_bitwarden_root_cert().clone()
     );
 
     if let Err(e) = invite_users(&config, &mut client, config.get_ldap_sync_loop()) {


### PR DESCRIPTION
... when connecting to the bitwarden_rs instance through http. This can be useful in corporate environments where certificates are issued by a local CA (or for self-signed certificates)